### PR TITLE
Introduces a timeout for the Captive Portal

### DIFF
--- a/lib/wifi_setup/wifi_setup.py
+++ b/lib/wifi_setup/wifi_setup.py
@@ -23,6 +23,7 @@ class WiFiSetup:
         self._credentials = Credentials()
         self._sta = network.WLAN(network.STA_IF)
         self._sta.active(True)
+        self.captive_timeout = None
 
     def has_ssid(self):
         return self._credentials.get()[0] is not None
@@ -36,7 +37,9 @@ class WiFiSetup:
         from wifi_setup.captive_portal import CaptivePortal
 
         # `run` will only return once WiFi is setup.
-        CaptivePortal().run(self._essid, self._connect_new)
+        CaptivePortal().run(
+            self._essid, self._connect_new, captive_timeout=self.captive_timeout
+        )
 
         return self._sta
 


### PR DESCRIPTION
The Captive Portal now can have a timeout. The idea is that it is shown only for a configurable amount of time, e.g. 15 minutes. After this timeout, the CP shuts down. This helps to prevent that a random person (i.e. a neighbor) can take over the device if the already-configured WiFi connection can't be established.

The default is `None`, which is consistent with the previous behaviour (Captive Portal stays alive until someone establishes a connection).